### PR TITLE
set rotation within void EyeManager::load_eye_images()

### DIFF
--- a/eye_display/include/eye.hpp
+++ b/eye_display/include/eye.hpp
@@ -186,6 +186,8 @@ void EyeManager::load_eye_images()
     const char *path_jpg_reflex = current_eye_asset.path_reflex.c_str();
     const char *path_jpg_upperlid = current_eye_asset.path_upperlid.c_str();
 
+    lcd.setRotation(current_eye_asset.direction);
+
     if (path_jpg_outline != NULL) {
         sprite_outline.fillScreen(TFT_WHITE);
         if (not draw_image_file(sprite_outline, path_jpg_outline)) {

--- a/eye_display/include/ros_lib.h
+++ b/eye_display/include/ros_lib.h
@@ -57,6 +57,8 @@ void setup_asset(EyeManager& eye)
     nh.spinOnce();
     delay(1000);
   }
+  delay(500);  // wait 0.5 sec before reading asset
+  nh.loginfo("Setup eye asset");
 
   bool mode_right;
   int direction = 1;


### PR DESCRIPTION
closes https://github.com/sktometometo/eye-display/pull/27#issuecomment-2789272365

```
ただ，目の表示方向に関する不思議な現象を観測したのでご報告します．
- launchしたときに，抜き差しした後の1回目は，direction=0の方向で画像が表示される
```